### PR TITLE
Export test data if NODE_ENV is 'test'

### DIFF
--- a/generators/app/templates/db/data/index.js
+++ b/generators/app/templates/db/data/index.js
@@ -1,7 +1,7 @@
 const ENV = process.env.NODE_ENV || 'development';
 
 const development = require('./dev-data');
-const test = require('./dev-data');
+const test = require('./test-data');
 
 const data = {
   development,


### PR DESCRIPTION
Template currently exports dev data even if NODE_ENV is set to 'test'. Change require path to point to test data.